### PR TITLE
added docker-compose version to .yml to fix unsupported config error 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+version: '3.3'
+
 services:
   jekyll:
     image: jekyll/jekyll:latest


### PR DESCRIPTION
The docker-compose.yml did not have a version at the start of the file which was causing it to throw an unsupported config error whenever docker-compose up was run.
Added a base version that should work with all the latest docker as well above 18.0+